### PR TITLE
Remove quotes around activation.announce nodes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,12 +7,12 @@ messages:
 activation:
     countdown: 15
     announce:
-    - '15'
-    - '5'
-    - '4'
-    - '3'
-    - '2'
-    - '1'
+    - 15
+    - 5
+    - 4
+    - 3
+    - 2
+    - 1
 whitelist:
 - ElieTGM
 


### PR DESCRIPTION
This allows the plugin to correctly announce countdown messages as (I would assume), they are currently being incorrectly treated as strings as opposed to integers